### PR TITLE
Fixing para sistema Linux Mint y Docker (NO version desktop)

### DIFF
--- a/app/common/constants.py
+++ b/app/common/constants.py
@@ -5,4 +5,4 @@ from chromadb.config import Settings
 #PERSIST_DIRECTORY = os.environ.get('PERSIST_DIRECTORY', 'db')
 
 # Define the Chroma settings
-CHROMA_SETTINGS = chromadb.HttpClient(host="host.docker.internal", port=8000, settings=Settings(allow_reset=True, anonymized_telemetry=False))
+CHROMA_SETTINGS = chromadb.HttpClient(host="chroma", port=8000, settings=Settings(allow_reset=True, anonymized_telemetry=False))

--- a/docker-compose_sin_gpu.yml
+++ b/docker-compose_sin_gpu.yml
@@ -7,6 +7,8 @@ services:
         - /ollama/models:/ollama/models
       environment:
         - OLLAMA_MODELS=/ollama/models
+      networks:
+        - net
     
     chroma:
       image: chromadb/chroma:latest
@@ -30,6 +32,8 @@ services:
         - MODEL=phi3
         - EMBEDDINGS_MODEL_NAME=all-MiniLM-L6-v2
         - TARGET_SOURCE_CHUNKS=5
+      networks:
+        - net
 
 volumes:
   index_data:


### PR DESCRIPTION
El problema aparece al momento de escribir `hola` en el campo de texto de la interfaz.  En la figura me sugiere dos problemas en archivos que han sido codificados por vos:
![basdonax-ai-rag-01](https://github.com/fcori47/basdonax-ai-rag/assets/6865706/a5a76827-0205-45d5-96bc-a7084c31254e)
Y según los errores es un problema de conectividad. Reviso que es `CHROMA_SETTINGS` y está en el archivo `./app/common/constants.py` y tiene lo siguiente:
```
CHROMA_SETTINGS = chromadb.HttpClient(host="host.docker.internal", port=8000, settings=Settings(allow_reset=True, anonymized_telemetry=False))
```
Pero ese nombre de  `host` no sé que es.  Entonces lo pongo a apuntar a `chroma` que es el nombre del servicio establecido en el archivo YAML `docker-compose_sin_gpu.yml`.

Pero algo que me sigue llamando la atención es que hay tres servicios definidos en el `docker-compose_sin_gpu.yml` (`ollama`, `chroma`, `ui`) y solo `chroma` está conectado a la red `net` definida en el YAML.  Sin embargo, decidí correr el `docker compose -f docker-compose_sin_gpu.yml up` nuevamente y apareció el mismo error al tipear `hola`. 

Así que opté por adicionar la red `net` en los demás servicios, `ollama` y `ui` y ahora el programa sí funciona.